### PR TITLE
Fix mobile stacking

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -27,9 +27,9 @@ const About = () => {
   }, []);
 
   return (
-    <section 
-      id="about" 
-      className="snap-section flex flex-col md:flex-row h-screen bg-charcoal"
+    <section
+      id="about"
+      className="snap-section flex flex-col md:flex-row md:h-screen bg-charcoal"
     >
       <div className="w-full md:w-1/2 h-1/2 md:h-full relative overflow-hidden">
         <div className="absolute inset-0 parallax">

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -4,9 +4,9 @@ import { Linkedin, Instagram } from "lucide-react";
 
 const ContactForm = () => {
   return (
-    <section 
-      id="contact" 
-      className="snap-section min-h-screen flex items-center bg-charcoal-dark py-8 px-6 md:px-12"
+    <section
+      id="contact"
+      className="snap-section md:min-h-screen flex items-center bg-charcoal-dark py-8 px-6 md:px-12"
     >
       <div className="container max-w-5xl mx-auto text-center">
         <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold mb-12 text-offwhite">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -9,9 +9,9 @@ const Hero = () => {
   }, []);
 
   return (
-    <section 
-      id="hero" 
-      className="relative snap-section flex items-center justify-center h-screen overflow-hidden bg-charcoal-dark"
+    <section
+      id="hero"
+      className="relative snap-section flex items-center justify-center md:h-screen overflow-hidden bg-charcoal-dark"
     >
       <div className="absolute inset-0 z-0 opacity-60">
         <div className="absolute inset-0 bg-gradient-to-b from-charcoal-dark/40 to-charcoal-dark/95"></div>

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -60,9 +60,9 @@ const Services = () => {
   ];
 
   return (
-    <section 
-      id="services" 
-      className="snap-section h-screen flex items-center bg-charcoal py-16 px-6 md:px-12"
+    <section
+      id="services"
+      className="snap-section md:h-screen flex items-center bg-charcoal py-16 px-6 md:px-12"
     >
       <div className="container max-w-7xl mx-auto">
         <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold mb-12 text-center text-offwhite">


### PR DESCRIPTION
## Summary
- make hero, about, services, and contact sections only full height on desktop

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855995f6cc8832cb62ace7348bbebf3