### PR TITLE
Fix header scroll effect and restore parallax

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -32,13 +32,10 @@ const About = () => {
       className="snap-section flex flex-col md:flex-row md:h-screen bg-charcoal"
     >
       <div className="w-full md:w-1/2 h-1/2 md:h-full relative overflow-hidden">
-        <div className="absolute inset-0 parallax">
-          <img 
-            src="https://images.unsplash.com/photo-1588681664899-f142ff2dc9b1"
-            alt="TV broadcasting studio with cameras and equipment" 
-            className="w-full h-full object-cover"
-            loading="lazy"
-          />
+        <div
+          className="absolute inset-0 parallax"
+          style={{ backgroundImage: "url('https://images.unsplash.com/photo-1588681664899-f142ff2dc9b1')" }}
+        >
           <div className="absolute inset-0 bg-gradient-to-r from-charcoal/70 to-transparent"></div>
         </div>
       </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -13,14 +13,11 @@ const Hero = () => {
       id="hero"
       className="relative snap-section flex items-center justify-center md:h-screen overflow-hidden bg-charcoal-dark"
     >
-      <div className="absolute inset-0 z-0 opacity-60">
+      <div
+        className="absolute inset-0 z-0 parallax"
+        style={{ backgroundImage: "url('https://images.unsplash.com/photo-1461896836934-ffe607ba8211')" }}
+      >
         <div className="absolute inset-0 bg-gradient-to-b from-charcoal-dark/40 to-charcoal-dark/95"></div>
-        <img 
-          src="https://images.unsplash.com/photo-1461896836934-ffe607ba8211"
-          alt="Sports stadium with crowd" 
-          className="w-full h-full object-cover object-center"
-          loading="eager" 
-        />
       </div>
 
       <div className="container relative z-10 px-6 md:px-12 max-w-7xl mx-auto text-center">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -8,20 +8,16 @@ const Navbar = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   useEffect(() => {
-    const container = document.getElementById("scroll-container");
-
     const handleScroll = () => {
-      const scrollTop = container ? container.scrollTop : window.scrollY;
-      setScrolled(scrollTop > 10);
+      setScrolled(window.scrollY > 10);
     };
 
     // Check initial scroll position in case page loads scrolled
     handleScroll();
 
-    const target = container || window;
-    target.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("scroll", handleScroll, { passive: true });
     return () => {
-      target.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("scroll", handleScroll);
     };
   }, []);
 
@@ -37,7 +33,7 @@ const Navbar = () => {
     <nav
       className={cn(
         "sticky top-0 left-0 w-full z-50 transition-all duration-300 px-6 py-4 md:px-12",
-        scrolled ? "bg-[#1a202c] shadow-lg backdrop-blur-sm" : "bg-transparent"
+        scrolled ? "bg-blue-700 shadow-lg backdrop-blur-sm" : "bg-transparent"
       )}
     >
       <div className="max-w-7xl mx-auto flex items-center justify-between">

--- a/src/index.css
+++ b/src/index.css
@@ -47,6 +47,7 @@
   html {
     scroll-behavior: smooth;
     @apply scroll-smooth;
+    scroll-snap-type: y mandatory;
   }
   
   body {
@@ -91,10 +92,6 @@
 
 .snap-container {
   scroll-snap-type: y mandatory;
-  height: 100vh;
-  overflow-y: scroll;
-  /* Improve scroll performance on mobile */
-  -webkit-overflow-scrolling: touch;
 }
 
 .snap-section {
@@ -106,7 +103,7 @@
 
 /* Mobile-specific fixes */
 @media (max-width: 768px) {
-  .snap-container {
+  html {
     /* Disable snap scrolling on mobile for better UX */
     scroll-snap-type: none;
   }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -19,14 +19,14 @@ const Index = () => {
   }, []);
 
   return (
-    <div id="scroll-container" className="snap-container">
+    <>
       <Navbar />
       <Hero />
       <About />
       <Services />
       <PullQuote />
       <ContactForm />
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- smooth header scroll detection with window events
- change scrolled header color to blue
- enable scroll snap on `html` and disable on mobile
- remove extra scroll container
- use CSS background images for parallax sections

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559b594bd4832caec6212b6f5d71ac