### PR TITLE
Enhance scroll animations

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,39 +1,17 @@
 
-import { useEffect, useState } from "react";
-
+import useInView from "@/hooks/useInView";
 const About = () => {
-  const [visible, setVisible] = useState(false);
-  
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setVisible(true);
-        }
-      },
-      { threshold: 0.2 }
-    );
-    
-    const section = document.getElementById("about");
-    if (section) {
-      observer.observe(section);
-    }
-    
-    return () => {
-      if (section) {
-        observer.unobserve(section);
-      }
-    };
-  }, []);
+  const { ref, inView } = useInView({ threshold: 0.2 });
 
   return (
     <section
+      ref={ref}
       id="about"
       className="snap-section flex flex-col md:flex-row md:h-screen bg-charcoal"
     >
       <div className="w-full md:w-1/2 h-1/2 md:h-full relative overflow-hidden">
         <div
-          className="absolute inset-0 parallax"
+          className="absolute inset-0"
           style={{ backgroundImage: "url('https://images.unsplash.com/photo-1588681664899-f142ff2dc9b1')" }}
         >
           <div className="absolute inset-0 bg-gradient-to-r from-charcoal/70 to-transparent"></div>
@@ -41,9 +19,9 @@ const About = () => {
       </div>
       
       <div className="w-full md:w-1/2 h-1/2 md:h-full flex items-center justify-center p-8 md:p-12 lg:p-16">
-        <div 
+        <div
           className={`transition-all duration-1000 delay-300 ${
-            visible ? "opacity-100 transform-none" : "opacity-0 translate-x-20"
+            inView ? "opacity-100 transform-none" : "opacity-0 translate-x-20"
           }`}
         >
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold mb-6 text-offwhite">
@@ -56,7 +34,7 @@ const About = () => {
           
           <div 
             className={`h-1 w-24 bg-copper transition-all duration-1000 delay-500 ${
-              visible ? "opacity-100 transform-none" : "opacity-0 scale-x-0"
+              inView ? "opacity-100 transform-none" : "opacity-0 scale-x-0"
             }`}
           ></div>
         </div>

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,14 +1,17 @@
 
 import React from "react";
+import useInView from "@/hooks/useInView";
 import { Linkedin, Instagram } from "lucide-react";
 
 const ContactForm = () => {
+  const { ref, inView } = useInView({ threshold: 0.2 });
   return (
     <section
+      ref={ref}
       id="contact"
       className="snap-section md:min-h-screen flex items-center bg-charcoal-dark py-8 px-6 md:px-12"
     >
-      <div className="container max-w-5xl mx-auto text-center">
+      <div className={`container max-w-5xl mx-auto text-center transition-all duration-1000 ${inView ? 'opacity-100 transform-none' : 'opacity-0 translate-y-10'}` }>
         <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold mb-12 text-offwhite">
           Get in <span className="text-copper">Touch</span>
         </h2>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,29 +1,25 @@
 
-import { useEffect, useState } from "react";
-
+import useInView from "@/hooks/useInView";
 const Hero = () => {
-  const [loaded, setLoaded] = useState(false);
-  
-  useEffect(() => {
-    setLoaded(true);
-  }, []);
+  const { ref, inView } = useInView({ threshold: 0.1 });
 
   return (
     <section
+      ref={ref}
       id="hero"
       className="relative snap-section flex items-center justify-center md:h-screen overflow-hidden bg-charcoal-dark"
     >
       <div
-        className="absolute inset-0 z-0 parallax"
+        className="absolute inset-0 z-0"
         style={{ backgroundImage: "url('https://images.unsplash.com/photo-1461896836934-ffe607ba8211')" }}
       >
         <div className="absolute inset-0 bg-gradient-to-b from-charcoal-dark/40 to-charcoal-dark/95"></div>
       </div>
 
       <div className="container relative z-10 px-6 md:px-12 max-w-7xl mx-auto text-center">
-        <div 
+        <div
           className={`transition-all duration-1000 ${
-            loaded ? "opacity-100 transform-none" : "opacity-0 translate-y-10"
+            inView ? "opacity-100 transform-none" : "opacity-0 translate-y-10"
           }`}
         >
           <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold mb-4 md:mb-6 text-shadow">

--- a/src/components/PullQuote.tsx
+++ b/src/components/PullQuote.tsx
@@ -1,44 +1,23 @@
 
-import { useEffect, useState } from "react";
-
+import useInView from "@/hooks/useInView";
 const PullQuote = () => {
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(([entry]) => {
-      if (entry.isIntersecting) {
-        setVisible(true);
-      }
-    }, {
-      threshold: 0.3
-    });
-
-    const section = document.getElementById("pullquote");
-    if (section) {
-      observer.observe(section);
-    }
-
-    return () => {
-      if (section) {
-        observer.unobserve(section);
-      }
-    };
-  }, []);
+  const { ref, inView } = useInView({ threshold: 0.3 });
 
   return (
     <section
+      ref={ref}
       id="pullquote"
       className="snap-start flex items-center bg-charcoal px-6 md:px-12 py-16"
     >
       <div className="container max-w-4xl mx-auto text-center">
-        <div className={`transition-all duration-1000 ${visible ? "opacity-100 transform-none" : "opacity-0 translate-y-10"}`}>
+        <div className={`transition-all duration-1000 ${inView ? "opacity-100 transform-none" : "opacity-0 translate-y-10"}`}>
           <blockquote className="text-3xl md:text-4xl lg:text-5xl font-bold text-offwhite font-playfair italic relative">
             <span className="text-copper text-6xl md:text-7xl absolute -top-4 -left-4 md:-left-8 opacity-50">"</span>
             Strategy without delivery is just expensive advice
             <span className="text-copper text-6xl md:text-7xl absolute -bottom-8 -right-4 md:-right-8 opacity-50">"</span>
           </blockquote>
           
-          <div className={`h-1 w-24 bg-copper mx-auto mt-12 transition-all duration-1000 delay-300 ${visible ? "opacity-100 transform-none" : "opacity-0 scale-x-0"}`}></div>
+          <div className={`h-1 w-24 bg-copper mx-auto mt-12 transition-all duration-1000 delay-300 ${inView ? "opacity-100 transform-none" : "opacity-0 scale-x-0"}`}></div>
         </div>
       </div>
     </section>

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,30 +1,7 @@
 
-import { useEffect, useState } from "react";
-
+import useInView from "@/hooks/useInView";
 const Services = () => {
-  const [visible, setVisible] = useState(false);
-  
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setVisible(true);
-        }
-      },
-      { threshold: 0.2 }
-    );
-    
-    const section = document.getElementById("services");
-    if (section) {
-      observer.observe(section);
-    }
-    
-    return () => {
-      if (section) {
-        observer.unobserve(section);
-      }
-    };
-  }, []);
+  const { ref, inView } = useInView({ threshold: 0.2 });
 
   const services = [
     {
@@ -61,6 +38,7 @@ const Services = () => {
 
   return (
     <section
+      ref={ref}
       id="services"
       className="snap-section md:h-screen flex items-center bg-charcoal py-16 px-6 md:px-12"
     >
@@ -74,8 +52,8 @@ const Services = () => {
             <div 
               key={index}
               className={`relative p-6 md:p-8 bg-charcoal-dark rounded-lg border border-charcoal overflow-hidden ${
-                visible 
-                  ? "opacity-100 transform-none" 
+                inView
+                  ? "opacity-100 transform-none"
                   : "opacity-0 translate-y-10"
               }`}
               style={{ transitionDelay: `${200 + index * 100}ms` }}

--- a/src/hooks/useInView.ts
+++ b/src/hooks/useInView.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef, useState } from "react";
+
+export default function useInView(options?: IntersectionObserverInit) {
+  const ref = useRef<HTMLElement | null>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        setInView(true);
+        observer.disconnect();
+      }
+    }, options);
+
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [options]);
+
+  return { ref, inView };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -62,16 +62,6 @@
 }
 
 @layer utilities {
-  .parallax {
-    background-attachment: fixed;
-    background-position: center;
-    background-repeat: no-repeat;
-    background-size: cover;
-    /* Disable parallax on mobile for better performance */
-    @media (max-width: 768px) {
-      background-attachment: scroll;
-    }
-  }
   
   .text-shadow {
     text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
## Summary
- remove legacy parallax class
- add `useInView` hook for Intersection Observer logic
- animate Hero, About, Services, PullQuote and Contact sections when scrolled into view

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559f069d78832ca5bc7f6408638836