### PR TITLE
Improve hero height on mobile

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -7,7 +7,7 @@ const Hero = () => {
     <section
       ref={ref}
       id="hero"
-      className="relative snap-section flex items-center justify-center md:h-screen overflow-hidden bg-charcoal-dark"
+      className="relative snap-section flex items-center justify-center min-h-[60vh] md:h-screen overflow-hidden bg-charcoal-dark"
     >
       <div
         className="absolute inset-0 z-0 bg-cover bg-center bg-no-repeat"


### PR DESCRIPTION
## Summary
- increase Hero section min-height on small screens so background image remains impactful

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855ac696710832c927f21aca7e309f9