### PR TITLE
Fix logo path for GitHub Pages

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -41,7 +41,7 @@ const Navbar = () => {
       <div className="max-w-7xl mx-auto flex items-center justify-between">
         <div>
           <img
-            src="/lovable-uploads/a40db039-1d09-4acb-99af-3b07f3f682b5.png"
+            src={`${import.meta.env.BASE_URL}lovable-uploads/a40db039-1d09-4acb-99af-3b07f3f682b5.png`}
             alt="Claymore Ventures Logo"
             role="button"
             aria-label="Home"


### PR DESCRIPTION
## Summary
- reference Vite's `BASE_URL` for the navbar logo

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855bfdb625c832c84fc2bb9e4928b10