### PR TITLE
Fix mobile service layout

### DIFF
--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -48,12 +48,12 @@ const Services = () => {
         </h2>
         
         <div
-          className="flex overflow-x-auto snap-x snap-mandatory scroll-smooth gap-6 md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-8 md:overflow-visible"
+          className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 md:gap-8"
         >
           {services.map((service, index) => (
             <div
               key={index}
-              className={`relative shrink-0 w-4/5 md:w-auto snap-center p-6 md:p-8 bg-charcoal-dark rounded-lg border border-charcoal overflow-hidden transition-all duration-1000 ${
+              className={`relative w-full p-6 md:p-8 bg-charcoal-dark rounded-lg border border-charcoal overflow-hidden transition-all duration-1000 ${
                 inView
                   ? "opacity-100 transform-none"
                   : "opacity-0 translate-y-10"


### PR DESCRIPTION
## Summary
- stack service cards vertically on mobile

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6855ca530f2c832c851dc85c21b14e55